### PR TITLE
Fix replay parsing

### DIFF
--- a/kittywork.Wc3ReplayParser.Business.Tests/ReplayParserTests.cs
+++ b/kittywork.Wc3ReplayParser.Business.Tests/ReplayParserTests.cs
@@ -38,6 +38,22 @@ public class ReplayParserTests
         Assert.Equal(2u, tr.Lumber);
     }
 
+    [Theory]
+    [InlineData("testdata/w3c-20250511132852.w3g")]
+    [InlineData("testdata/w3c-20250511135035.w3g")]
+    [InlineData("testdata/w3c-20250511135332.w3g")]
+    [InlineData("testdata/w3c-20250511141650.w3g")]
+    [InlineData("testdata/w3c-20250511145524.w3g")]
+    [InlineData("testdata/w3c-20250511151824.w3g")]
+    public void Parse_RealReplays_Success(string path)
+    {
+        var fullPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../..", path));
+        var parser = new ReplayParser();
+        var info = parser.Parse(fullPath);
+        Assert.False(string.IsNullOrEmpty(info.GameId));
+        Assert.NotNull(info.Events);
+    }
+
     private static byte[] CreateTestReplay()
     {
         var buffer = new List<byte>();
@@ -76,13 +92,13 @@ public class ReplayParserTests
         decompressed.AddRange(action);
         var uncompressedBytes = decompressed.ToArray();
         var compMs = new MemoryStream();
-        using(var ds = new DeflateStream(compMs, CompressionLevel.Optimal, true))
+        using(var ds = new ZLibStream(compMs, CompressionLevel.Optimal, leaveOpen: true))
             ds.Write(uncompressedBytes,0,uncompressedBytes.Length);
         compMs.Position = 0;
         var compBytes = compMs.ToArray();
         var block = new List<byte>();
-        block.AddRange(BitConverter.GetBytes((ushort)compBytes.Length));
-        block.AddRange(BitConverter.GetBytes((ushort)uncompressedBytes.Length));
+        block.AddRange(BitConverter.GetBytes((uint)compBytes.Length));
+        block.AddRange(BitConverter.GetBytes((uint)uncompressedBytes.Length));
         block.AddRange(new byte[4]);
         block.AddRange(compBytes);
         var header = new List<byte>();

--- a/kittywork.Wc3ReplayParser.Business/ReplayParser.cs
+++ b/kittywork.Wc3ReplayParser.Business/ReplayParser.cs
@@ -48,12 +48,13 @@ public class ReplayParser : IReplayParser
         var decompressed = new MemoryStream();
         for (int i = 0; i < blockCount; i++)
         {
-            ushort compLen = reader.ReadUInt16();
-            ushort decompLen = reader.ReadUInt16();
+            // W3Champions replay format uses 32-bit lengths
+            uint compLen = reader.ReadUInt32();
+            uint decompLen = reader.ReadUInt32();
             reader.ReadUInt32(); // checksum
-            var compBytes = reader.ReadBytes(compLen);
+            var compBytes = reader.ReadBytes((int)compLen);
             using var ms = new MemoryStream(compBytes);
-            using var ds = new DeflateStream(ms, CompressionMode.Decompress);
+            using var ds = new ZLibStream(ms, CompressionMode.Decompress);
             ds.CopyTo(decompressed);
         }
         var events = new List<ReplayEvent>();

--- a/kittywork.Wc3ReplayParser.Business/ReplayParser.cs
+++ b/kittywork.Wc3ReplayParser.Business/ReplayParser.cs
@@ -69,6 +69,8 @@ public class ReplayParser : IReplayParser
             {
                 byte blockId = br.ReadByte();
                 if (blockId != 0x1F && blockId != 0x1E)
+                    continue; // skip unknown data until an action block marker
+                if (br.BaseStream.Position + 4 > br.BaseStream.Length)
                     break;
                 ushort blockLen = br.ReadUInt16();
                 ushort timeInc = br.ReadUInt16();


### PR DESCRIPTION
## Summary
- update `ReplayParser` to handle W3Champions replay files using ZLibStream and 32-bit block sizes
- adjust tests and add new tests for provided testdata

## Testing
- `dotnet test kittywork.Wc3ReplayParser.sln`
- `dotnet test kittywork.HelloWorld.sln`


------
https://chatgpt.com/codex/tasks/task_e_6845b660ff708327a406c1e609eb0b8a