### PR TITLE
Add extension for unknown replay events

### DIFF
--- a/kittywork.Wc3ReplayParser.Business.Tests/ReplayInfoExtensionsTests.cs
+++ b/kittywork.Wc3ReplayParser.Business.Tests/ReplayInfoExtensionsTests.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using kittywork.Wc3ReplayParser.Business;
+
+namespace kittywork.Wc3ReplayParser.Business.Tests;
+
+public class ReplayInfoExtensionsTests
+{
+    [Fact]
+    public void GetUnknownEvents_ReturnsUnknownActions()
+    {
+        var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../..", "testdata/w3c-20250511132852.w3g"));
+        var parser = new ReplayParser();
+        var info = parser.Parse(path);
+        var unknownEvents = info.GetUnknownEvents().ToList();
+        Assert.NotEmpty(unknownEvents);
+        Assert.All(unknownEvents, e => Assert.IsType<UnknownAction>(e.Action));
+    }
+
+    [Fact]
+    public void Parse_RealReplay_ParsesChatMessages()
+    {
+        var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../..", "testdata/w3c-20250511145524.w3g"));
+        var parser = new ReplayParser();
+        var info = parser.Parse(path);
+        Assert.Contains(info.Events, e => e.Action is ChatMessageAction);
+        Assert.Contains(info.Events, e => e.Action is MinimapPingAction);
+        Assert.Contains(info.Events, e => e.Action is MmdMessageAction);
+    }
+}

--- a/kittywork.Wc3ReplayParser.Business/ActionParser.cs
+++ b/kittywork.Wc3ReplayParser.Business/ActionParser.cs
@@ -74,6 +74,16 @@ internal static class ActionParser
                 uint gold = br.ReadUInt32();
                 uint lumber = br.ReadUInt32();
                 return new TransferResourcesAction(slot, gold, lumber);
+            case 0x60:
+                uint a = br.ReadUInt32();
+                uint b = br.ReadUInt32();
+                string msg = ReadString(br);
+                return new ChatMessageAction(a, b, msg);
+            case 0x62:
+                uint x32 = br.ReadUInt32();
+                uint y32 = br.ReadUInt32();
+                uint pingFlags = br.ReadUInt32();
+                return new MinimapPingAction(x32, y32, pingFlags);
             case 0x75:
                 byte arrow = br.ReadByte();
                 return new ArrowKeyAction(arrow);
@@ -100,6 +110,12 @@ internal static class ActionParser
                 float val = br.ReadSingle();
                 string text = ReadString(br);
                 return new CommandFrameAction(eventId32, val, text);
+            case 0x6B:
+                string tag = ReadString(br);
+                string value2 = ReadString(br);
+                string text2 = ReadString(br);
+                uint data2 = br.ReadUInt32();
+                return new MmdMessageAction(tag, value2, text2, data2);
             default:
                 var remaining = br.ReadBytes((int)(br.BaseStream.Length - br.BaseStream.Position));
                 return new UnknownAction(id, remaining);

--- a/kittywork.Wc3ReplayParser.Business/Actions.cs
+++ b/kittywork.Wc3ReplayParser.Business/Actions.cs
@@ -107,6 +107,21 @@ public record CommandFrameAction(uint EventId, float Val, string Text) : ReplayA
     public override string Explain() => $"CommandFrame event {EventId} val={Val} text={Text}";
 }
 
+public record ChatMessageAction(uint UnknownA, uint UnknownB, string Message) : ReplayAction(0x60)
+{
+    public override string Explain() => $"Chat message '{Message}'";
+}
+
+public record MinimapPingAction(uint X, uint Y, uint Flags) : ReplayAction(0x62)
+{
+    public override string Explain() => $"Minimap ping at ({X},{Y}) flags=0x{Flags:X}";
+}
+
+public record MmdMessageAction(string Tag, string Value, string Text, uint Data) : ReplayAction(0x6B)
+{
+    public override string Explain() => $"MMD {Tag} {Value} {Text} data={Data}";
+}
+
 public record NetTag(uint A, uint B)
 {
     public override string ToString() => $"[{A:X8},{B:X8}]";

--- a/kittywork.Wc3ReplayParser.Business/ReplayInfoExtensions.cs
+++ b/kittywork.Wc3ReplayParser.Business/ReplayInfoExtensions.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace kittywork.Wc3ReplayParser.Business;
+
+public static class ReplayInfoExtensions
+{
+    public static IEnumerable<ReplayEvent> GetUnknownEvents(this ReplayInfo replayInfo)
+    {
+        if (replayInfo == null)
+            throw new ArgumentNullException(nameof(replayInfo));
+
+        return replayInfo.Events.Where(e => e.Action is UnknownAction);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ReplayInfoExtensions.GetUnknownEvents` for enumerating unknown actions
- parse new actions: chat messages, minimap pings, MMD messages
- test that real replays contain the new actions and unknown events

## Testing
- `dotnet test kittywork.Wc3ReplayParser.sln --no-build -v minimal`
- `dotnet build kittywork.Wc3ReplayParser.sln -c Release -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6845bcdd19fc8327893f9d7f6ea2671b