### PR TITLE
Improve replay log formatting

### DIFF
--- a/kittywork.Wc3ReplayParser.Business.Tests/ReplayEventTests.cs
+++ b/kittywork.Wc3ReplayParser.Business.Tests/ReplayEventTests.cs
@@ -1,0 +1,65 @@
+using System.IO.Compression;
+using System.Text;
+using kittywork.Wc3ReplayParser.Business;
+
+namespace kittywork.Wc3ReplayParser.Business.Tests;
+
+public class ReplayEventTests
+{
+    [Fact]
+    public void ToString_FormatsTimeAsHumanReadable()
+    {
+        var data = CreateReplayWithEvent();
+        using var ms = new MemoryStream(data);
+        var parser = new ReplayParser();
+        var info = parser.Parse(ms);
+        var evt = info.Events[0];
+        Assert.StartsWith("00:00:01.000", evt.ToString());
+    }
+
+    private static byte[] CreateReplayWithEvent()
+    {
+        var decompressed = new List<byte>();
+        decompressed.AddRange(new byte[]{0,0,0,0});
+        decompressed.Add(0x1F);
+        var action = new List<byte>();
+        action.Add(0x51); // action id
+        action.Add(0x02); // slot
+        action.AddRange(BitConverter.GetBytes((uint)1));
+        action.AddRange(BitConverter.GetBytes((uint)2));
+        ushort blockLen = (ushort)(2 + 3 + action.Count);
+        decompressed.AddRange(BitConverter.GetBytes(blockLen));
+        decompressed.AddRange(BitConverter.GetBytes((ushort)1000));
+        decompressed.Add(0x00);
+        decompressed.AddRange(BitConverter.GetBytes((ushort)action.Count));
+        decompressed.AddRange(action);
+        var uncompressedBytes = decompressed.ToArray();
+        var compMs = new MemoryStream();
+        using(var ds = new ZLibStream(compMs, CompressionLevel.Optimal, leaveOpen: true))
+            ds.Write(uncompressedBytes,0,uncompressedBytes.Length);
+        compMs.Position = 0;
+        var compBytes = compMs.ToArray();
+        var block = new List<byte>();
+        block.AddRange(BitConverter.GetBytes((uint)compBytes.Length));
+        block.AddRange(BitConverter.GetBytes((uint)uncompressedBytes.Length));
+        block.AddRange(new byte[4]);
+        block.AddRange(compBytes);
+        var header = new List<byte>();
+        header.AddRange(Encoding.ASCII.GetBytes("Warcraft III recorded game"));
+        header.Add(0x1A);
+        header.Add(0x00);
+        header.AddRange(BitConverter.GetBytes((uint)0x44));
+        header.AddRange(BitConverter.GetBytes((uint)block.Count));
+        header.AddRange(BitConverter.GetBytes((uint)1));
+        header.AddRange(BitConverter.GetBytes((uint)uncompressedBytes.Length));
+        header.AddRange(BitConverter.GetBytes((uint)1));
+        header.AddRange(Encoding.ASCII.GetBytes("W3XP"));
+        header.AddRange(BitConverter.GetBytes((uint)0x00010000));
+        header.AddRange(BitConverter.GetBytes((ushort)1));
+        header.AddRange(BitConverter.GetBytes((ushort)0x8000));
+        header.AddRange(BitConverter.GetBytes((uint)1000));
+        header.AddRange(BitConverter.GetBytes((uint)0));
+        header.AddRange(block);
+        return header.ToArray();
+    }
+}

--- a/kittywork.Wc3ReplayParser.Business/ReplayEvent.cs
+++ b/kittywork.Wc3ReplayParser.Business/ReplayEvent.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace kittywork.Wc3ReplayParser.Business;
 
 public record ReplayEvent(
@@ -5,5 +7,10 @@ public record ReplayEvent(
     byte PlayerId,
     ReplayAction Action)
 {
-    public override string ToString() => $"{TimeMs}ms Player {PlayerId}: {Action.Explain()}";
+    public override string ToString()
+    {
+        var ts = TimeSpan.FromMilliseconds(TimeMs);
+        var timeText = ts.ToString(@"hh\:mm\:ss\.fff");
+        return $"{timeText} Player {PlayerId}: {Action.Explain()}";
+    }
 }

--- a/kittywork.Wc3ReplayParser.Console/Program.cs
+++ b/kittywork.Wc3ReplayParser.Console/Program.cs
@@ -8,8 +8,10 @@ if (args.Length == 0)
 
 var parser = new ReplayParser();
 var info = parser.Parse(args[0]);
-Console.WriteLine($"Game: {info.GameId} Version: {info.Version} Build: {info.Build} Length(ms): {info.GameLengthMs}");
+var duration = TimeSpan.FromMilliseconds(info.GameLengthMs);
+Console.WriteLine($"Game: {info.GameId} Version: {info.Version} Build: {info.Build} Length: {duration:hh\\:mm\\:ss}");
 foreach (var e in info.Events)
 {
     Console.WriteLine(e.ToString());
 }
+Console.WriteLine($"Summary: {info.Events.Count} events, duration {duration:hh\\:mm\\:ss}");


### PR DESCRIPTION
## Summary
- format replay timestamps in a human readable form
- print a summary after listing events
- test timestamp formatting logic

## Testing
- `dotnet build kittywork.Wc3ReplayParser.sln -v minimal`
- `dotnet test kittywork.Wc3ReplayParser.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6845ca0b6f28832780498c9f9ad34374