### PR TITLE
Document unknown opcode events

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ dotnet test kittywork.Wc3ReplayParser.sln
 
 The console application prints the replay header and lists all parsed action blocks with timestamps.
 
+## Unknown actions
+
+Running the console against the sample replays reveals several opcode IDs that
+the parser does not recognize. Example IDs are `0x00`, `0x02`, `0x1A`, `0x61`,
+`0x66`, `0x67`, `0x68`, `0x6A`, `0x7A` and `0xBC`. Web searches did not uncover
+documentation for these codes so their semantics remain unclear. They appear in
+the output as `UnknownAction` entries. Contributions that clarify these opcodes
+are welcome.
+


### PR DESCRIPTION
## Summary
- note in README that the console logs unknown action opcodes

## Testing
- `dotnet build kittywork.Wc3ReplayParser.sln`
- `dotnet test kittywork.Wc3ReplayParser.sln`


------
https://chatgpt.com/codex/tasks/task_e_6845cc20fd2c8327b927fb32541d847f